### PR TITLE
feat(theme): Simplify and automate banner path resolution

### DIFF
--- a/layouts/list.json.json
+++ b/layouts/list.json.json
@@ -14,7 +14,16 @@
       {
         "title": {{ $p.Title | jsonify }},
         "description": {{ $p.Description | jsonify }},
-        "banner": {{ $p.Params.Banner | absURL | jsonify }},
+        // "banner": {{ $p.Params.Banner | absURL | jsonify }},
+
+        {{- $banner_url := "" -}}
+        {{- with $p.Resources.GetMatch $p.Params.Banner -}}
+          {{- $banner_url = .Permalink -}}
+        {{- else -}}
+          {{- $banner_url = $p.Params.Banner | absURL -}}
+        {{- end -}}
+        "banner": {{ $banner_url | jsonify }},
+
         "slug": {{ or $p.Slug $p.File.ContentBaseName | jsonify }},
         "permalink": {{ $p.Permalink | jsonify }},
         "level": {{ $p.Params.level | jsonify }},

--- a/layouts/list.json.json
+++ b/layouts/list.json.json
@@ -11,19 +11,21 @@
 
       {{- $children := $p.Pages }}
 
+      {{- $banner_url := "" -}}
+      {{- if $p.Params.Banner -}} {{/* 1. 首先确保 banner 字段不为空 */}}
+        {{- if strings.HasPrefix $p.Params.Banner $uuid -}}
+          {{- /* 2. 如果 banner 已经包含 orgId (旧数据)，就直接用，保证兼容 */ -}}
+          {{- $banner_url = $p.Params.Banner | absURL -}}
+        {{- else -}}
+          {{- /* 3. 如果不包含 orgId (新数据)，就用 printf 自动拼接 */ -}}
+          {{- $banner_url = printf "%s/%s" $uuid $p.Params.Banner | absURL -}}
+        {{- end -}}
+      {{- end -}}
+      
       {
         "title": {{ $p.Title | jsonify }},
         "description": {{ $p.Description | jsonify }},
-        // "banner": {{ $p.Params.Banner | absURL | jsonify }},
-
-        {{- $banner_url := "" -}}
-        {{- with $p.Resources.GetMatch $p.Params.Banner -}}
-          {{- $banner_url = .Permalink -}}
-        {{- else -}}
-          {{- $banner_url = $p.Params.Banner | absURL -}}
-        {{- end -}}
         "banner": {{ $banner_url | jsonify }},
-
         "slug": {{ or $p.Slug $p.File.ContentBaseName | jsonify }},
         "permalink": {{ $p.Permalink | jsonify }},
         "level": {{ $p.Params.level | jsonify }},

--- a/layouts/list.json.json
+++ b/layouts/list.json.json
@@ -11,13 +11,10 @@
 
       {{- $children := $p.Pages }}
 
+      {{- /* Prepend the orgId to the parent Learning Path's banner path. */ -}}
       {{- $banner_url := "" -}}
       {{- if $p.Params.Banner -}}
-        {{- if strings.HasPrefix $p.Params.Banner $uuid -}}
-          {{- $banner_url = $p.Params.Banner | absURL -}}
-        {{- else -}}
-          {{- $banner_url = printf "%s/%s" $uuid $p.Params.Banner | absURL -}}
-        {{- end -}}
+        {{- $banner_url = printf "%s/%s" $uuid $p.Params.Banner | absURL -}}
       {{- end -}}
 
       {
@@ -34,13 +31,10 @@
           {{- range $j, $c := $children }}
             {{- if $j }},{{ end }}
 
+            {{- /* Prepend the orgId to the nested Course's banner path. */ -}}
             {{- $course_banner_url := "" -}}
             {{- if $c.Params.Banner -}}
-                {{- if strings.HasPrefix $c.Params.Banner $uuid -}}
-                  {{- $course_banner_url = $c.Params.Banner | absURL -}}
-                {{- else -}}
-                  {{- $course_banner_url = printf "%s/%s" $uuid $c.Params.Banner | absURL -}}
-                {{- end -}}
+              {{- $course_banner_url = printf "%s/%s" $uuid $c.Params.Banner | absURL -}}
             {{- end -}}
 
             {

--- a/layouts/list.json.json
+++ b/layouts/list.json.json
@@ -50,7 +50,7 @@
               "level": {{ $c.Params.level | jsonify }},
               "description": {{ $c.Description | jsonify }},
               "weight": {{ $c.Params.Order | jsonify}},
-              "banner": {{ $c.Params.Banner | absURL | jsonify }},
+              "banner": {{ $course_banner_url | jsonify }},
               "permalink": {{ $c.Permalink | jsonify }}
             }
           {{- end }}

--- a/layouts/list.json.json
+++ b/layouts/list.json.json
@@ -12,16 +12,14 @@
       {{- $children := $p.Pages }}
 
       {{- $banner_url := "" -}}
-      {{- if $p.Params.Banner -}} {{/* 1. 首先确保 banner 字段不为空 */}}
+      {{- if $p.Params.Banner -}}
         {{- if strings.HasPrefix $p.Params.Banner $uuid -}}
-          {{- /* 2. 如果 banner 已经包含 orgId (旧数据)，就直接用，保证兼容 */ -}}
           {{- $banner_url = $p.Params.Banner | absURL -}}
         {{- else -}}
-          {{- /* 3. 如果不包含 orgId (新数据)，就用 printf 自动拼接 */ -}}
           {{- $banner_url = printf "%s/%s" $uuid $p.Params.Banner | absURL -}}
         {{- end -}}
       {{- end -}}
-      
+
       {
         "title": {{ $p.Title | jsonify }},
         "description": {{ $p.Description | jsonify }},
@@ -35,6 +33,16 @@
         "courses": [
           {{- range $j, $c := $children }}
             {{- if $j }},{{ end }}
+
+            {{- $course_banner_url := "" -}}
+            {{- if $c.Params.Banner -}}
+                {{- if strings.HasPrefix $c.Params.Banner $uuid -}}
+                  {{- $course_banner_url = $c.Params.Banner | absURL -}}
+                {{- else -}}
+                  {{- $course_banner_url = printf "%s/%s" $uuid $c.Params.Banner | absURL -}}
+                {{- end -}}
+            {{- end -}}
+
             {
               "title": {{ $c.Title | jsonify }},
               "slug": {{ or $c.Slug $c.File.ContentBaseName | jsonify }},


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #46

#### **Problem**

The previous method for defining `banner` image paths in front matter required a hardcoded, full path including the `orgId` (e.g., `98e16360.../images/icon.svg`). This was verbose and inconvenient for content creators.

#### **Solution**

This PR updates the Hugo template (`layouts/list.json.json`):
-   The template now automatically prepends the correct `orgId` to any `banner` path that doesn't already start with it.
-   This logic is applied to both top-level "Learning Paths" and their nested "Courses".
-   This allows authors to use a much simpler relative path (e.g., `images/icon.svg` or `logo/icons.svg`) in the front matter.

#### **Testing Method**

I conducted local testing using the `academy-build` repository, configured with `go mod replace` to use my local theme and content modules. I created several test cases in the front matter of course files with various `banner` formats, including:

-   **New simplified path:** `banner: "images/icon.svg"`
-   **Old full path (for compatibility):** `banner: "98e16360.../images/icon.svg"`

I then ran `make academy-prod` and inspected the generated `public/learning-paths/index.json` file.

#### **Result**

The tests were successful and confirmed the logic works as expected:

-   Simplified paths were correctly prepended with the `orgId` to form a full, valid URL.
-   Full paths were handled correctly without modification

----

Based on Aabid's recommendation, I have simplified the logic and deprecating the old method that involved org ID.