### PR TITLE
fix: Make default tags and categories hyperlinks black

### DIFF
--- a/assets/scss/_tax_project.scss
+++ b/assets/scss/_tax_project.scss
@@ -129,7 +129,7 @@
       background: none;
       border-width: 0;
       border-radius: 0;
-      color: $secondary;
+      color: black !important;
       font-size: 1em;
       line-height: 1.5em;
       min-height: 1.5em;


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #58 

All hyperlinks use our representative green color, but taxonomy tags need black color as a special case, requiring !important to override.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
