### PR TITLE
add support for badges on completion

### DIFF
--- a/layouts/partials/badge.html
+++ b/layouts/partials/badge.html
@@ -1,0 +1,21 @@
+{{- $b := .badge -}}
+{{- $contentId := .curriculaId -}}
+{{- $orgId := .orgId | default "" -}}
+
+{{- $svg := cond (partial "is-url.html" $b.svg) $b.svg (partial "banner-url.html" (dict "uuid" $orgId "banner" $b.svg )) -}}
+{{- $png := cond (partial "is-url.html" $b.png) $b.png (partial "banner-url.html" (dict "uuid" $orgId "banner" $b.svg )) -}}
+
+{{- $badge := "nil" -}}
+
+{{- if $b }}
+    {{- $badge =  dict
+      "title" $b.title
+      "description" $b.description
+      "label" $contentId
+      "svg" $svg
+      "png" $png
+    -}}
+{{- end -}}
+
+
+{{- return  $badge -}}

--- a/layouts/partials/is-url.html
+++ b/layouts/partials/is-url.html
@@ -1,0 +1,3 @@
+{{- $s := . -}}
+{{- $isUrl := or (strings.HasPrefix $s "http://") (strings.HasPrefix $s "https://") -}}
+{{- return $isUrl -}}

--- a/layouts/partials/learning-path.json.html
+++ b/layouts/partials/learning-path.json.html
@@ -23,7 +23,7 @@
     "title": {{ .Title | jsonify }},
     "description": {{ .Description | jsonify }},
     "banner": {{ $banner_url | jsonify }},
-    "badge": {{ .Params.badge | jsonify }},
+    "badge": {{ partial "badge.html" (dict "badge" .Params.badge "curriculaId" $id "orgId" $uuid ) | jsonify }},
     "certificate": {{ .Params.certificate | jsonify }},
     "permalink": {{ .Permalink | jsonify }},
     "categories": {{ .Params.Categories | jsonify }},


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

Learning Paths , challenges and certifications now support a completion badge . the badges gets assigned after users complete the curricula . 

the badge can be specifiec in the frontmatter of the curricula ( In _index.md ) in the following format : 

```
badge: 
    png: "https://images.credly.com/images/f28f1d88-428a-47f6-95b5-7da1dd6c1000/twitter_thumb_201604_KCNA_badge.png"
    svg: "https://images.credly.com/images/f28f1d88-428a-47f6-95b5-7da1dd6c1000/twitter_thumb_201604_KCNA_badge.png"
    title: "Exoscale Certified"
    description: "Earn the Exoscale Certification badge to showcase your expertise in Exoscale cloud services."

```

the png and svg can be both a local image ( same format as banner url ) or a remote url .
 




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
