### PR TITLE
[Bug Fix] Underline on quiz content in side bar on hover

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -221,7 +221,7 @@ a:not([href]):not([class]):hover {
   a {
     &:hover {
       color: dark;
-      text-decoration: none;
+      text-decoration: underline;
     }
 
     &.active:not(.tree-root) {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #



<img width="268" height="202" alt="image" src="https://github.com/user-attachments/assets/10efe18a-064d-4cdb-a568-ef3253afbc2c" />

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
