### PR TITLE
fix: negative check on marks of questions

### DIFF
--- a/layouts/test/single.json.json
+++ b/layouts/test/single.json.json
@@ -25,7 +25,11 @@
   "prerequisites": {{ $prerequisites | jsonify }},
   "total_marks": {{- $total := 0 -}}
     {{- range $p.questions }}
-      {{- $total = add $total (or .marks 0) }}
+      {{- $marks := or .marks 0 }}
+      {{- if lt $marks 0 }}
+        {{- $marks = 0 }}
+      {{- end }}
+      {{- $total = add $total $marks }}
     {{- end }}
     {{ $total }},
   "parent": {{- with .Parent -}}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #


- Get the marks value (defaults to 0 if not set)
- Check if marks is less than 0 using lt (less than), and if so, set it to 0
- Add the validated marks to the total

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
