### PR TITLE
added feature to calculate total reading time

### DIFF
--- a/layouts/content.html
+++ b/layouts/content.html
@@ -3,9 +3,13 @@
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta{{ if or .Params.categories .Params.tags }} article-meta-bg{{ end }}">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}
-		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
-			{{ partial "reading-time.html" . -}}
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+		{{ if and (or (eq .Type "course") (eq .Type "learning-path")) (gt (len .RegularPagesRecursive) 0) }}
+			<div>Reading time: {{ partial "aggregate-reading-time.html" . }} min</div>
+		{{ else }}
+			{{ partial "reading-time.html" . }}
 		{{ end -}}
+	{{ end -}}
 	</header>
 	{{ with .Params.plan }}
         {{ partial "plan-info.html" (dict "plan" .) }}

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -2,18 +2,21 @@
 <div class="td-content">
    <h1>{{ .Title }}</h1>
    {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
-   
-   {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable) (or (eq .Params.type "page") (eq .Params.type "module"))) -}}
-         {{ partial "reading-time.html" . -}}
-   {{ end -}}
+   {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+      {{ if or (eq .Type "course") (eq .Type "learning-path") }}
+         <div>Reading time: {{ partial "aggregate-reading-time.html" . }} min</div>
+      {{ else }}
+         {{ partial "reading-time.html" . }}
+      {{ end -}}
+   {{ end -}}   
+
    <header class="article-meta{{ if or .Params.categories .Params.tags }} article-meta-bg{{ end }}">
       {{ partial "taxonomy_terms_article_wrapper.html" . -}}
    </header>
-
    {{ with .Params.plan }}
       {{ partial "plan-info.html" (dict "plan" .) }}
    {{ end }}
-
+      
    {{ .Content }}
    {{ partial "section-index.html" . -}}
 
@@ -21,7 +24,7 @@
       <br />
       {{- partial "disqus-comment.html" . -}}
    {{ end -}}
-
+      
    {{ partial "pager.html" . }}
    {{ partial "page-meta-lastmod.html" . -}}
 </div>

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -1,19 +1,26 @@
 {{ define "main" }}
 <div class="td-content">
    <h1>{{ .Title }}</h1>
-   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
-   
+   {{ with .Params.description }}
+     <div class="lead">{{ . | markdownify }}</div>
+   {{ end }}
+
    <header class="article-meta{{ if or .Params.categories .Params.tags }} article-meta-bg{{ end }}">
       {{ partial "taxonomy_terms_article_wrapper.html" . -}}
+
       {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
-         {{ partial "reading-time.html" . -}}
+         {{ if or (eq .Type "course") (eq .Type "learning-path") }}
+            <div>Reading time: {{ partial "aggregate-reading-time.html" . }} min</div>
+         {{ else }}
+            {{ partial "reading-time.html" . }}
+         {{ end -}}
       {{ end -}}
    </header>
-   
+
    {{ with .Params.plan }}
       {{ partial "plan-info.html" (dict "plan" .) }}
    {{ end }}
-   
+
    {{ .Content }}
    {{ partial "section-index.html" . -}}
 
@@ -21,7 +28,7 @@
       <br />
       {{- partial "disqus-comment.html" . -}}
    {{ end -}}
-   
+
    {{ partial "pager.html" . }}
    {{ partial "page-meta-lastmod.html" . -}}
 </div>

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -2,6 +2,7 @@
 <div class="td-content">
    <h1>{{ .Title }}</h1>
    {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+   
    {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
       {{ if or (eq .Type "course") (eq .Type "learning-path") }}
          <div>Reading time: {{ partial "aggregate-reading-time.html" . }} min</div>
@@ -9,14 +10,14 @@
          {{ partial "reading-time.html" . }}
       {{ end -}}
    {{ end -}}   
-
    <header class="article-meta{{ if or .Params.categories .Params.tags }} article-meta-bg{{ end }}">
       {{ partial "taxonomy_terms_article_wrapper.html" . -}}
    </header>
+   
    {{ with .Params.plan }}
       {{ partial "plan-info.html" (dict "plan" .) }}
    {{ end }}
-      
+   
    {{ .Content }}
    {{ partial "section-index.html" . -}}
 
@@ -24,7 +25,7 @@
       <br />
       {{- partial "disqus-comment.html" . -}}
    {{ end -}}
-      
+   
    {{ partial "pager.html" . }}
    {{ partial "page-meta-lastmod.html" . -}}
 </div>

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -5,7 +5,7 @@
    
    {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
       {{ if or (eq .Type "course") (eq .Type "learning-path") }}
-         <div>Reading time: {{ partial "aggregate-reading-time.html" . }} min</div>
+         <div>Reading time: {{ partial "aggregate-reading-time.html" . }}</div>
       {{ else }}
          {{ partial "reading-time.html" . }}
       {{ end -}}

--- a/layouts/partials/aggregate-reading-time.html
+++ b/layouts/partials/aggregate-reading-time.html
@@ -1,0 +1,5 @@
+{{- $total := 0 -}}
+{{- range .RegularPagesRecursive -}}
+  {{- $total = add $total .ReadingTime -}}
+{{- end -}}
+{{- $total -}}

--- a/layouts/partials/aggregate-reading-time.html
+++ b/layouts/partials/aggregate-reading-time.html
@@ -2,4 +2,8 @@
 {{- range .RegularPagesRecursive -}}
   {{- $total = add $total .ReadingTime -}}
 {{- end -}}
-{{- $total -}}
+{{- if lt $total 1 -}}
+  less than 1 min
+{{- else -}}
+  {{ $total }} min
+{{- end -}}

--- a/layouts/partials/course.json.html
+++ b/layouts/partials/course.json.html
@@ -1,6 +1,7 @@
 
 {
   {{ partial "common-curricula-properties.html" . }},
+  "total_reading_time": {{ partial "aggregate-reading-time.html" .page }},
   "children": [
     {{- range $k, $m := .page.Pages }}
       {{- if $k }},{{ end }}

--- a/layouts/partials/learning-path.json.html
+++ b/layouts/partials/learning-path.json.html
@@ -36,6 +36,7 @@
     "total_tests": {{ len (where .Pages "Type" "test") }},
     "total_modules": {{ len (where .Pages "Type" "module") }},
     "total_pages": {{ len (where .Pages "Type" "page") }},
+    "total_reading_time": {{ partial "aggregate-reading-time.html" . }},
 
     "children": [
       {{- range $j, $c := .Pages }}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #106 

I added a partial to calculate the aggregate reading time of courses and learning paths recursively. Also, added a conditional to `list.html` and `single.html` to render reading time based on type. I also added the new total reading time to JSON of course and learning path, so the data is available to the JS code.



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
