### PR TITLE
Fix: Compounding Time To Read For Learning Paths and Courses

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,7 @@
+readingTime:
+  one: "{{ .Count }} minute read"
+  other: "{{ .Count }} minutes read"
+
+readingTimeHours:
+  one: "{{ .Count }} hour read"
+  other: "{{ .Count }} hours read"

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -3,7 +3,7 @@
    <h1>{{ .Title }}</h1>
    {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
    
-   {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable) (or (eq .Params.type "page") (eq .Params.type "module"))) -}}
+   {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
          {{ partial "reading-time.html" . -}}
    {{ end -}}
    <header class="article-meta{{ if or .Params.categories .Params.tags }} article-meta-bg{{ end }}">

--- a/layouts/partials/reading-time.html
+++ b/layouts/partials/reading-time.html
@@ -1,0 +1,44 @@
+{{- $totalReadingTime := 0 -}}
+{{- $isLPOrCourse := or (eq .Params.type "learning-path") -}}
+
+{{- if eq .Params.type "learning-path" -}}
+  {{- range .Pages -}}
+    {{- if eq .Params.type "course" -}}
+      {{- range .Pages -}}
+        {{- if eq .Params.type "module" -}}
+          {{- range .Pages -}}
+            {{- $totalReadingTime = add $totalReadingTime .ReadingTime -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- else if eq .Params.type "course" -}}
+  {{- range .Pages -}}
+    {{- if eq .Params.type "module" -}}
+      {{- range .Pages -}}
+        {{- $totalReadingTime = add $totalReadingTime .ReadingTime -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- else if eq .Params.type "module" -}}
+  {{- range .Pages -}}
+    {{- $totalReadingTime = add $totalReadingTime .ReadingTime -}}
+  {{- end -}}
+  {{- $totalReadingTime = mul (div (add $totalReadingTime 5) 10) 10 -}}
+{{- else -}}
+  {{- $totalReadingTime = .ReadingTime -}}
+{{- end -}}
+
+{{- if gt $totalReadingTime 0 -}}
+<div class="reading-time">
+  <i class="fa-solid fa-clock" style="margin-right:5px; margin-bottom: 5px"></i>
+  {{- if $isLPOrCourse -}}
+    {{- $hours := math.Ceil (div (float $totalReadingTime) 60.0) -}}
+    {{ T "readingTimeHours" (dict "Count" $hours) }}
+  {{- else -}}
+    {{ T "readingTime" $totalReadingTime }}
+  {{- end -}}
+</div>
+{{- end -}}
+


### PR DESCRIPTION
**Notes for Reviewers**

This PR add the cumulative sum of lower level to upper level of heirarchy.
1. Learning Path -> Cumulative Sum of courses and added to the nearest hour.
<img width="1911" height="953" alt="Screenshot from 2025-08-27 20-17-42" src="https://github.com/user-attachments/assets/a1aa8b3e-ed57-480c-b889-38f7a5022446" />

2. Courses -> Cumulative Sum of modules and added to nearest x0 minutes (10, 20, 30)
<img width="1911" height="953" alt="Screenshot from 2025-08-27 20-17-48" src="https://github.com/user-attachments/assets/0f2fa72b-d800-4d29-b494-7aa1697f7f15" />

3. Modules -> Cumulative Sum of pages and added to nearest x0 minutes (10, 20, 30)
<img width="1911" height="953" alt="Screenshot from 2025-08-27 20-17-55" src="https://github.com/user-attachments/assets/946542f9-5572-46a1-bcef-ffb9cca5163a" />

4.  Pages 
<img width="1911" height="953" alt="Screenshot from 2025-08-27 20-18-00" src="https://github.com/user-attachments/assets/db520c33-723b-4495-85f5-4120f7907ba7" />





**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
