### PR TITLE
Fix: Resolve undefined variable "$svg" error in badge.html

### DIFF
--- a/layouts/partials/badge.html
+++ b/layouts/partials/badge.html
@@ -11,7 +11,7 @@
       "name" $b.title
       "description" $b.description
       "label" $contentId
-      "image_url" $svg
+      "image_url" $image_url
     -}}
 {{- end -}}
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

Related PR: https://github.com/layer5io/academy-theme/pull/118/files

Fixes the following error:
```
zihank@2-MesheryVM:~/layer5/exoscale-academy$ make site
Checking if Go is installed...
Go is installed.
hugo server -D -F
go: no module dependencies to download
go: added github.com/layer5io/academy-theme v0.3.2
go: added github.com/twbs/bootstrap v5.3.8+incompatible
hugo: downloading modules …
go: added github.com/FortAwesome/Font-Awesome v4.7.0+incompatible
hugo: collected modules in 2598 msError: "/home/zihank/layer5/academy-theme/layouts/partials/badge.html:14:1": parse of template failed: template: _partials/badge.html:14: undefined variable "$svg"
make: *** [Makefile:27: site] Error 1
zihank@2-MesheryVM:~/layer5/exoscale-academy$ 
```