### PR TITLE
[CI] Add area/certifications to labeler workflow configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,3 +6,7 @@ area/challenges:
 - changed-files:
   - any-glob-to-any-file:
     - "content/en/challenges/**/*"
+area/certifications:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "content/en/certifications/**/*"


### PR DESCRIPTION
Fixed #133 

### ✅ **PR Description**

**Summary**
This pull request updates the labeler workflow configuration to include the `area/certifications` label. This ensures that any changes made within the certifications content directory are automatically tagged with the correct label.

**Changes Made**

* Added configuration block to apply the label `area/certifications` for files under:
  `content/en/certifications/**/*`

**Purpose**
This update improves issue and PR categorization by ensuring certification-related updates are properly labeled and easier to track.

