### PR TITLE
fix: resolve incorrect URLs for pre-quiz tests missing /academy prefix

### DIFF
--- a/layouts/test/single.html
+++ b/layouts/test/single.html
@@ -349,9 +349,9 @@
 {{ $tesAbsPath := .RelPermalink }}
 
 <script>
-    const testId = {{$test.id}};
+    const testId = {{ $test.id | jsonify }};
     const testAbsPath = "{{$tesAbsPath}}";
-    const build = {{$build}};
+    const build = {{ $build | jsonify }};
 
 
     // Event Listeners
@@ -377,7 +377,7 @@
     window.addEventListener("academyContextReady", () => {
         if (isProdBuild && window.academyContext?.RegistrationData?.id) {
             // redirect to test page 
-            const curriculaRoot = window.location.pathname.split("/").slice(0, 5).join("/");
+            const curriculaRoot = {{ .RelPermalink | strings.TrimSuffix "/" | jsonify }};
             window.location.replace(`${curriculaRoot}/test?id=${testId}&registration_id=${window.academyContext?.RegistrationData?.id}&test_abs_path=${testAbsPath}`);
             return;
         }


### PR DESCRIPTION
**Notes for Reviewers**
This PR fixes #127

## What was the problem?
Pre-quiz test URLs were missing the `/academy` prefix.
The `curriculaRoot` variable was built using hardcoded `.slice(0, 5)` on 
`window.location.pathname` at runtime, which generated incorrect URLs 
like `/learning-paths/xxx` instead of `/academy/learning-paths/xxx`.

## What was changed?
**File:** `layouts/test/single.html`

Replaced the hardcoded JavaScript path-splitting logic:
```js
const curriculaRoot = window.location.pathname.split("/").slice(0, 5).join("/");
```
With Hugo's `RelPermalink` which injects the correct full path at build time:
```js
const curriculaRoot = "{{ .RelPermalink | strings.TrimSuffix "/" }}";
```

## Why this fix?
Hugo's `.RelPermalink` correctly includes the `/academy` base path prefix 
at build time — no runtime path manipulation needed.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.