### PR TITLE
Fix academy test launcher

### DIFF
--- a/layouts/test/single.html
+++ b/layouts/test/single.html
@@ -347,11 +347,13 @@
 
 {{ $test := partial "test/single.html" . }}
 {{ $tesAbsPath := .RelPermalink }}
+{{ $curriculaRoot := .RelPermalink | strings.TrimSuffix "/" | strings.TrimSuffix "/test" }}
 
 <script>
-    const testId = {{ $test.id | jsonify }};
-    const testAbsPath = "{{$tesAbsPath}}";
-    const build = {{ $build | jsonify }};
+    const testId = {{ $test.id | jsonify | safeJS }};
+    const testAbsPath = {{ $tesAbsPath | jsonify | safeJS }};
+    const build = {{ $build | jsonify | safeJS }};
+    const curriculaRoot = {{ $curriculaRoot | jsonify | safeJS }};
 
 
     // Event Listeners
@@ -376,8 +378,6 @@
     // Initialize when context is ready
     window.addEventListener("academyContextReady", () => {
         if (isProdBuild && window.academyContext?.RegistrationData?.id) {
-            // redirect to test page 
-            const curriculaRoot = {{ .RelPermalink | strings.TrimSuffix "/" | jsonify }};
             window.location.replace(`${curriculaRoot}/test?id=${testId}&registration_id=${window.academyContext?.RegistrationData?.id}&test_abs_path=${testAbsPath}`);
             return;
         }


### PR DESCRIPTION
**Notes for Reviewers**

- This fixes the Academy test launcher regression in `layouts/test/single.html`. The emitted script was producing invalid JS string values.

Examples:
- before, the launcher could emit `build='"production"'` instead of `build="production"`, so `build === "production"` evaluated false and the redirect never ran
  - before, a page at /academy/certifications/<orgId>/certified-meshery-contributor/meshery-extensibility/test/ could derive curriculaRoot as /academy/.../meshery-extensibility/test, then redirect to /academy/.../
    meshery-extensibility/test/test?...
  - after this patch, the same page derives curriculaRoot as /academy/.../meshery-extensibility, so the redirect becomes /academy/.../meshery-extensibility/test?.

  The patch uses jsonify | safeJS for launcher literals and trims the trailing /test when deriving the parent redirect base.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
