### PR TITLE
make current curricula as root of left navigation panel

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -36,11 +36,11 @@
     {{ $offset := 1 }}
 
     {{ if eq (index $pathSegments 1) "academy" }}
-    {{ $offset = 2 }} 
+    {{ $offset = 2 }}
     {{ end }}
 
     {{ if ge (len $pathSegments) (add $offset 4) }}
-    
+
     {{ $toplevel := index $pathSegments $offset }}
     {{ $orgId := index $pathSegments (add $offset 1) }}
     {{ $pathSlug := index $pathSegments (add $offset 2) }}
@@ -49,9 +49,7 @@
 
         {{ $currentPathRootURL := printf "/%s/%s/%s/" $toplevel $orgId $pathSlug }}
 
-        {{ if eq $offset 2 }}
-            {{ $currentPathRootURL = printf "/%s%s" (index $pathSegments 1) $currentPathRootURL }}
-        {{ end }}
+
 
         {{ $currentPathRootPage := .Site.GetPage $currentPathRootURL }}
 

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -45,7 +45,7 @@
     {{ $orgId := index $pathSegments (add $offset 1) }}
     {{ $pathSlug := index $pathSegments (add $offset 2) }}
 
-    {{ if or (eq $toplevel "learning-paths") (eq $toplevel "challenges") }}
+    {{ if or (eq $toplevel "learning-paths") (eq $toplevel "challenges") (eq $toplevel "certifications") }}
 
         {{ $currentPathRootURL := printf "/%s/%s/%s/" $toplevel $orgId $pathSlug }}
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

before : 
![Uploading image.png…]()


after 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/864e9198-2cbc-4302-8e07-38e4e086c246" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
