### PR TITLE
feat: add org-id shortcode

### DIFF
--- a/layouts/shortcodes/org-id.html
+++ b/layouts/shortcodes/org-id.html
@@ -2,7 +2,7 @@
   Renders the organization ID (UUID) of the current page's organization.
   Academy content is organized as content/<type>/<orgID>/... so this
   shortcode extracts the orgID at file path segment index 1.
-  Usage: {{</* org-id */>}}
+  Usage: org-id shortcode (no parameters)
   Example output:
   <code class="org-id">550e8400-e29b-41d4-a716-446655440000</code>
 */}}

--- a/layouts/shortcodes/org-id.html
+++ b/layouts/shortcodes/org-id.html
@@ -1,15 +1,8 @@
 {{/*
   Renders the organization ID (UUID) of the current page's organization.
-
   Academy content is organized as content/<type>/<orgID>/... so this
   shortcode extracts the orgID at file path segment index 1.
-
-  The page must reside inside a valid org directory (a UUID-named segment)
-  for the shortcode to locate the ID. If the orgID cannot be determined,
-  a fallback message is rendered instead.
-
   Usage: {{</* org-id */>}}
-
   Example output:
   <code class="org-id">550e8400-e29b-41d4-a716-446655440000</code>
 */}}
@@ -19,8 +12,8 @@
   {{- if ge (len $parts) 2 -}}
     {{- $candidate := index $parts 1 -}}
     {{- if gt (len (findRE `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$` $candidate)) 0 -}}
-      {{- $orgID = $candidate -}}
+      {{- $orgID = lower $candidate -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- if $orgID -}}<code class="org-id">{{ $orgID }}</code>{{- else -}}<code class="org-id org-id--not-found">(org ID not found)</code>{{- end -}}
+{{- if $orgID -}}<code class="org-id">{{ $orgID }}</code>{{- else -}}<code class="org-id org-id--not-found">{{ i18n "org_id_not_found" | default "(org ID not found)" }}</code>{{- end -}}

--- a/layouts/shortcodes/org-id.html
+++ b/layouts/shortcodes/org-id.html
@@ -1,0 +1,26 @@
+{{/*
+  Renders the organization ID (UUID) of the current page's organization.
+
+  Academy content is organized as content/<type>/<orgID>/... so this
+  shortcode extracts the orgID at file path segment index 1.
+
+  The page must reside inside a valid org directory (a UUID-named segment)
+  for the shortcode to locate the ID. If the orgID cannot be determined,
+  a fallback message is rendered instead.
+
+  Usage: {{</* org-id */>}}
+
+  Example output:
+  <code class="org-id">550e8400-e29b-41d4-a716-446655440000</code>
+*/}}
+{{- $orgID := "" -}}
+{{- with .Page.File -}}
+  {{- $parts := split .Path "/" -}}
+  {{- if ge (len $parts) 2 -}}
+    {{- $candidate := index $parts 1 -}}
+    {{- if gt (len (findRE `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$` $candidate)) 0 -}}
+      {{- $orgID = $candidate -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $orgID -}}<code class="org-id">{{ $orgID }}</code>{{- else -}}<code class="org-id org-id--not-found">(org ID not found)</code>{{- end -}}


### PR DESCRIPTION
## Summary

- Adds new `{{< org-id >}}` shortcode at `layouts/shortcodes/org-id.html`

## What it does

The `org-id` shortcode renders the current organization's UUID inline, extracted automatically from the page's content path.

Academy content is structured as `content/<type>/<orgID>/...`, so the shortcode splits the file path and reads the UUID at segment index 1. It validates the value against the standard UUID regex pattern (matching the same logic used in `collect-content-health.html`) before rendering.

**Usage:**
```markdown
Your organization ID is: {{< org-id >}}
```

**Output** (when page is inside an org directory):
```html
<code>550e8400-e29b-41d4-a716-446655440000</code>
```

If the page is not inside a valid UUID-named directory, the shortcode renders `(org ID not found)`.

## Test plan

- [ ] Add `{{< org-id >}}` to a page inside `content/learning-paths/<uuid>/...` in academy-example and verify the UUID renders correctly
- [ ] Verify the fallback message renders on a page outside a UUID directory (e.g., `content/content-formatting-examples/...`)