### PR TITLE
chore: upgrade Go version to 1.26.4

### DIFF
--- a/.github/workflows/bump-academy-version.yml
+++ b/.github/workflows/bump-academy-version.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout academy-theme code 
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26.4'
 
       - name: Checkout dependent repo
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/layer5io/academy-theme
 
-go 1.24.5
-
-require github.com/google/docsy v0.12.0 // indirect
+go 1.26.4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.12.0 h1:CddZKL39YyJzawr8GTVaakvcUTCJRAAYdz7W0qfZ2P4=
-github.com/google/docsy v0.12.0/go.mod h1:1bioDqA493neyFesaTvQ9reV0V2vYy+xUAnlnz7+miM=
-github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
## Changes
- Updated `go.mod` Go version from `1.24` to `1.26.4`
- Updated `go-version` in `.github/workflows/bump-academy-version.yml`

Fixes #217