### PR TITLE
Fix favicon 86

### DIFF
--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,9 +1,9 @@
-<link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
-<link rel="manifest" href="/favicons/site.webmanifest">
-<link rel="mask-icon" href="/favicons/safari-pinned-tab.svg">
-<link rel="shortcut icon" href="/favicons/favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href='{{ "favicons/apple-touch-icon.png" | relURL }}'>
+<link rel="icon" type="image/png" sizes="32x32" href='{{ "favicons/favicon-32x32.png" | relURL }}'>
+<link rel="icon" type="image/png" sizes="16x16" href='{{ "favicons/favicon-16x16.png" | relURL }}'>
+<link rel="manifest" href='{{ "favicons/site.webmanifest" | relURL }}'>
+<link rel="mask-icon" href='{{ "favicons/safari-pinned-tab.svg" | relURL }}'>
+<link rel="shortcut icon" href='{{ "favicons/favicon.ico" | relURL }}'>
 <meta name="msapplication-TileColor" content="#da532c">
-<meta name="msapplication-config" content="/favicons/browserconfig.xml">
+<meta name="msapplication-config" content='{{ "favicons/browserconfig.xml" | relURL }}'>
 <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
**Notes for Reviewers**

I updated layouts/partials/favicon.html to properly wrap all image paths in Hugo's relURL function (e.g., href='{{ "favicons/favicon.ico" | relURL }}') and removed the leading slashes.

This ensures that Hugo dynamically resolves the correct favicon path regardless of the deployment baseURL or subdirectory, allowing the browser to successfully load the Layer5 "5" logos that are already bundled in the theme.

<img width="729" height="225" alt="{D31DAD8D-9158-4058-9255-5771B296689E}" src="https://github.com/user-attachments/assets/7653f943-0d98-458a-b9ec-edb72e3832b1" />


This PR fixes #86 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [✅ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
