### PR TITLE
[chore]: remove npm and go cache from bump-academy-version workflow

### DIFF
--- a/.github/workflows/bump-academy-version.yml
+++ b/.github/workflows/bump-academy-version.yml
@@ -31,13 +31,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
 
       - name: Install dependencies
         run: make setup


### PR DESCRIPTION
## Summary

This PR fixes a workflow failure caused by strict dependency caching rules across the repository matrix.

### Changes
* **Removed Node Cache:** The `academy-build` repository does not use a `package-lock.json` file. Removing `cache: 'npm'` prevents the workflow from failing on repositories that lack a lock file.
* **Disabled Go Cache:** Set `cache: false` because the workflow dynamically runs `make theme-update`, which modifies `go.mod` and regenerates `go.sum`. Caching is unnecessary since the dependency tree shifts during execution.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
