### PR TITLE
[Academy Validation] Respect build draft mode in content ID validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ Registry lookups are scoped to root learning paths, challenges, and
 certifications. Nested course/module/page/test IDs are not checked against the
 Cloud curriculum registry.
 
-Validation respects the build's draft mode. Draft content is only validated
-when the build actually renders it (`hugo --buildDrafts`); those drafts are
-checked softly and never block publishing. When draft mode is off, draft
-modules are not part of the build and are skipped entirely — they are neither
-checked against the registry nor reported as warnings.
+Validation respects the build's draft mode. Draft root content is only
+validated when the build actually renders it (`hugo --buildDrafts`); those
+drafts are checked softly and never block publishing. When draft mode is off,
+draft root content is not part of the build and is skipped entirely — it is
+neither checked against the registry nor reported as warnings.
 
 If `params.academy.registryURL` is not configured, the build prints one
 configuration warning and does not report existing IDs as invalid because they

--- a/README.md
+++ b/README.md
@@ -173,9 +173,14 @@ Supported `validationMode` values:
 - `off` suppresses content health warnings and skips registry lookups.
 
 Registry lookups are scoped to root learning paths, challenges, and
-certifications. Draft root content is not warning-producing and is hidden from
-the Instructor Toolkit report. Nested course/module/page/test IDs are not
-checked against the Cloud curriculum registry.
+certifications. Nested course/module/page/test IDs are not checked against the
+Cloud curriculum registry.
+
+Validation respects the build's draft mode. Draft content is only validated
+when the build actually renders it (`hugo --buildDrafts`); those drafts are
+checked softly and never block publishing. When draft mode is off, draft
+modules are not part of the build and are skipped entirely — they are neither
+checked against the registry nor reported as warnings.
 
 If `params.academy.registryURL` is not configured, the build prints one
 configuration warning and does not report existing IDs as invalid because they

--- a/layouts/partials/academy-validation/collect-content-health.html
+++ b/layouts/partials/academy-validation/collect-content-health.html
@@ -69,7 +69,11 @@
     {{- $fix := "" -}}
     {{- $registryStatus := "" -}}
     {{- $cloudStatus := "" -}}
-    {{- $isDraft := or .Draft (eq (printf "%v" .Params.draft | lower) "true") -}}
+    {{- /* A page only carries a Hugo draft flag inside $site.Pages when the build
+           itself included drafts (hugo --buildDrafts). Treat that as "draft mode on"
+           for this content: it is being rendered, so validate it softly below. */ -}}
+    {{- $draftBuilt := or .Draft (eq (printf "%v" .Params.draft | lower) "true") -}}
+    {{- $isDraft := $draftBuilt -}}
     {{- if not $isDraft -}}
       {{- $sourcePath := printf "content/%s" $filePath -}}
       {{- $source := try (os.ReadFile $sourcePath) -}}
@@ -85,7 +89,14 @@
       {{- $draft = add $draft 1 -}}
     {{- end -}}
 
-    {{- if not (partial "academy-validation/validate-academy-org-id.html" $orgID) -}}
+    {{- if and $isDraft (not $draftBuilt) -}}
+      {{- /* Content is marked draft but the build's draft mode is off (Hugo is not
+             rendering it). Respect the build mode and skip validation entirely so we
+             never check or warn on draft modules that are not part of this build. */ -}}
+      {{- $status = "draft" -}}
+      {{- $issue = "Draft content is not validated while the build's draft mode is off." -}}
+      {{- $fix = "Build with drafts enabled (--buildDrafts) to validate this draft, or publish it." -}}
+    {{- else if not (partial "academy-validation/validate-academy-org-id.html" $orgID) -}}
       {{- $status = "broken" -}}
       {{- $issue = "Content is outside a valid organization directory." -}}
       {{- $fix = "Move this root content under content/<type>/<org-id>/<slug>/." -}}
@@ -117,7 +128,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and $isDraft (ne $status "good") -}}
+    {{- if and $draftBuilt (ne $status "good") -}}
       {{- $status = "draft_warning" -}}
       {{- if eq $issue "" -}}
         {{- $issue = "Draft content could not be fully validated." -}}

--- a/layouts/partials/academy-validation/collect-content-health.html
+++ b/layouts/partials/academy-validation/collect-content-health.html
@@ -69,10 +69,12 @@
     {{- $fix := "" -}}
     {{- $registryStatus := "" -}}
     {{- $cloudStatus := "" -}}
-    {{- /* A page only carries a Hugo draft flag inside $site.Pages when the build
-           itself included drafts (hugo --buildDrafts). Treat that as "draft mode on"
-           for this content: it is being rendered, so validate it softly below. */ -}}
-    {{- $draftBuilt := or .Draft (eq (printf "%v" .Params.draft | lower) "true") -}}
+    {{- /* .Draft is Hugo's build-aware draft state: a page only carries it inside
+           $site.Pages when the build itself rendered drafts (hugo --buildDrafts).
+           Treat that as "draft mode on" for this content and validate it softly below.
+           $isDraft additionally covers content marked draft in front matter on disk;
+           when such content is not being built it is skipped rather than validated. */ -}}
+    {{- $draftBuilt := .Draft -}}
     {{- $isDraft := $draftBuilt -}}
     {{- if not $isDraft -}}
       {{- $sourcePath := printf "content/%s" $filePath -}}

--- a/layouts/shortcodes/instructor-toolkit.html
+++ b/layouts/shortcodes/instructor-toolkit.html
@@ -106,6 +106,8 @@
                 ✅
               {{- else if eq .status "unchecked" -}}
                 Not checked
+              {{- else if eq .status "draft" -}}
+                Draft
               {{- else -}}
                 {{- if ne $consoleURL "" -}}<a href="{{ $consoleURL }}" target="_blank" rel="noopener" aria-label="Open Instructor Console">❌</a>{{- else -}}❌{{- end -}}
               {{- end -}}


### PR DESCRIPTION
**Notes for Reviewers**

Content ID validation now respects the build's draft mode so that draft modules are not validated when draft mode is off.

Previously, content marked as draft could still be run through the full org/ID/registry validation and softened to a `draft_warning`, emitting a build warning even when the build was not rendering drafts. This change ties draft handling to Hugo's build-aware page state:

- **Draft mode off** (plain `hugo`): draft content is not part of the build and is skipped entirely — never checked against the registry and never reported as a warning. Content detected as draft on disk while the build is not rendering it gets a neutral `draft` status instead of a warning.
- **Draft mode on** (`hugo --buildDrafts`, e.g. PR previews): drafts are still validated softly (`draft_warning`) and never block publishing — unchanged behavior.

Changes:
- `layouts/partials/academy-validation/collect-content-health.html` — derive draft state from Hugo's `--buildDrafts`-aware page status; skip validation for draft content that is not being built; only downgrade *built* drafts to `draft_warning`.
- `layouts/shortcodes/instructor-toolkit.html` — render the neutral `draft` status in the report table.
- `README.md` — document the draft-mode-aware validation behavior.

Verified with an isolated Hugo build: with draft mode off the draft learning path is excluded and unvalidated; with `--buildDrafts` it appears as a non-blocking `draft_warning`. The Instructor Toolkit report renders correctly in both cases.

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

---
_Generated by [Claude Code](https://claude.ai/code)_