### PR TITLE
Respect build draft mode in content ID validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,14 @@ Supported `validationMode` values:
 - `off` suppresses content health warnings and skips registry lookups.
 
 Registry lookups are scoped to root learning paths, challenges, and
-certifications. Draft root content is not warning-producing and is hidden from
-the Instructor Toolkit report. Nested course/module/page/test IDs are not
-checked against the Cloud curriculum registry.
+certifications. Nested course/module/page/test IDs are not checked against the
+Cloud curriculum registry.
+
+Validation respects the build's draft mode. Draft content is only validated
+when the build actually renders it (`hugo --buildDrafts`); those drafts are
+checked softly and never block publishing. When draft mode is off, draft
+modules are not part of the build and are skipped entirely — they are neither
+checked against the registry nor reported as warnings.
 
 If `params.academy.registryURL` is not configured, the build prints one
 configuration warning and does not report existing IDs as invalid because they

--- a/layouts/partials/academy-validation/collect-content-health.html
+++ b/layouts/partials/academy-validation/collect-content-health.html
@@ -69,7 +69,11 @@
     {{- $fix := "" -}}
     {{- $registryStatus := "" -}}
     {{- $cloudStatus := "" -}}
-    {{- $isDraft := or .Draft (eq (printf "%v" .Params.draft | lower) "true") -}}
+    {{- /* A page only carries a Hugo draft flag inside $site.Pages when the build
+           itself included drafts (hugo --buildDrafts). Treat that as "draft mode on"
+           for this content: it is being rendered, so validate it softly below. */ -}}
+    {{- $draftBuilt := or .Draft (eq (printf "%v" .Params.draft | lower) "true") -}}
+    {{- $isDraft := $draftBuilt -}}
     {{- if not $isDraft -}}
       {{- $sourcePath := printf "content/%s" $filePath -}}
       {{- $source := try (os.ReadFile $sourcePath) -}}
@@ -85,7 +89,14 @@
       {{- $draft = add $draft 1 -}}
     {{- end -}}
 
-    {{- if not (partial "academy-validation/validate-academy-org-id.html" $orgID) -}}
+    {{- if and $isDraft (not $draftBuilt) -}}
+      {{- /* Content is marked draft but the build's draft mode is off (Hugo is not
+             rendering it). Respect the build mode and skip validation entirely so we
+             never check or warn on draft modules that are not part of this build. */ -}}
+      {{- $status = "draft" -}}
+      {{- $issue = "Draft content is not validated while the build's draft mode is off." -}}
+      {{- $fix = "Build with drafts enabled (--buildDrafts) to validate this draft, or publish it." -}}
+    {{- else if not (partial "academy-validation/validate-academy-org-id.html" $orgID) -}}
       {{- $status = "broken" -}}
       {{- $issue = "Content is outside a valid organization directory." -}}
       {{- $fix = "Move this root content under content/<type>/<org-id>/<slug>/." -}}
@@ -117,7 +128,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and $isDraft (ne $status "good") -}}
+    {{- if and $draftBuilt (ne $status "good") -}}
       {{- $status = "draft_warning" -}}
       {{- if eq $issue "" -}}
         {{- $issue = "Draft content could not be fully validated." -}}

--- a/layouts/shortcodes/instructor-toolkit.html
+++ b/layouts/shortcodes/instructor-toolkit.html
@@ -106,6 +106,8 @@
                 ✅
               {{- else if eq .status "unchecked" -}}
                 Not checked
+              {{- else if eq .status "draft" -}}
+                Draft
               {{- else -}}
                 {{- if ne $consoleURL "" -}}<a href="{{ $consoleURL }}" target="_blank" rel="noopener" aria-label="Open Instructor Console">❌</a>{{- else -}}❌{{- end -}}
               {{- end -}}


### PR DESCRIPTION
Draft modules are now only validated when the build actually renders them (hugo --buildDrafts). When draft mode is off, draft content is skipped entirely instead of being run through registry validation, so it is neither checked nor reported as a warning.

Draft state is derived from Hugo's build-aware page status; the file-based draft fallback now marks such content with a neutral draft status and skips validation rather than emitting a draft warning. Drafts that are being built keep the existing soft draft_warning behaviour and never block publishing.

**Notes for Reviewers**

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
