### PR TITLE
feat: update shortcode usage

### DIFF
--- a/layouts/shortcodes/chapterstyle.html
+++ b/layouts/shortcodes/chapterstyle.html
@@ -1,4 +1,16 @@
-{{ $style := .Get "style" | default "" }}
-<div class="chapter-content"{{ with $style }} style="{{ . }}"{{ end }}>
-  {{ .Inner | .Page.RenderString }}
+{{/*
+  Shortcode to wrap markdown content in a styled chapter container.
+  Usage:
+  {{< chapter >}}
+    Your markdown content goes here.
+  {{< /chapter >}}
+
+  {{< chapter style="columns: 2; text-align: justify;" >}}...{{< /chapter >}}
+
+  Params:
+  style - optional inline CSS declarations applied to the wrapper.
+*/}}
+{{- $style := .Get "style" -}}
+<div class="chapter-content"{{ with $style }} style="{{ . | safeCSS }}"{{ end }}>
+  {{ .Page.RenderString (dict "display" "block") .Inner }}
 </div>

--- a/layouts/shortcodes/chapterstyle.html
+++ b/layouts/shortcodes/chapterstyle.html
@@ -1,11 +1,11 @@
 {{/*
   Shortcode to wrap markdown content in a styled chapter container.
   Usage:
-  {{< chapter >}}
+  {{< chapterstyle >}}
     Your markdown content goes here.
-  {{< /chapter >}}
+  {{< /chapterstyle >}}
 
-  {{< chapter style="columns: 2; text-align: justify;" >}}...{{< /chapter >}}
+  {{< chapterstyle style="columns: 2; text-align: justify;" >}}...{{< /chapterstyle >}}
 
   Params:
   style - optional inline CSS declarations applied to the wrapper.

--- a/layouts/shortcodes/csvtable-roles.html
+++ b/layouts/shortcodes/csvtable-roles.html
@@ -1,33 +1,67 @@
-{{ $data := "" }} 
-{{ $p := "static/data/csv/keys-backup.csv" }} 
-{{ $excludedColumns := slice 0 10 11 12 13 14 15 16 17 18 }} 
+{{/*
+  Renders a permissions CSV as one table per role, listing the permissions
+  that role has access to.
+  Usage:
+  {{< role-tables src="keys-backup.csv" >}}
+  {{< role-tables src="static/data/csv/keys-backup.csv" >}}
 
-{{ if os.FileExists $p }} 
-  {{ $opts := dict "delimiter" "," }} 
-  {{ $data = (os.ReadFile $p | transform.Unmarshal $opts) }} 
-{{ else }} 
-  {{ errorf "Unable to get resource %q" $p }} 
-{{ end }} 
+  Params:
+  src - path to the CSV. Resolved against the page bundle first, then
+        assets/, then the project root.
 
-{{ if $data }} 
-  {{ $uniqueCategories := slice }} 
-  {{ $stopAddingCategories := false }} 
+  Expected CSV shape: row 1 is the header, columns 2 and 3 are Function and
+  Feature, role columns run from column 5 up to "Keychain ID". A row is
+  listed under a role when that role's cell is X or X*.
+*/}}
+{{- $src := .Get "src" -}}
+{{- $opts := dict "delimiter" "," -}}
+{{- $data := "" -}}
 
-  {{ range $i, $header := index $data 1 }} 
-    {{ if gt $i 3 }} 
-      {{ if eq $header "Keychain ID" }} 
-        {{ $stopAddingCategories = true }} 
-      {{ end }} 
+{{- if not $src -}}
+  {{- errorf "role-tables: src required. See %s" .Position -}}
+{{- else -}}
+  {{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
+    {{- $data = transform.Unmarshal $opts . -}}
+  {{- else -}}
+    {{- if os.FileExists $src -}}
+      {{- $data = transform.Unmarshal $opts (os.ReadFile $src) -}}
+    {{- else -}}
+      {{- errorf "role-tables: %q not found in page bundle, assets, or project root. See %s" $src .Position -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 
-      {{ if not $stopAddingCategories }} 
-        {{ if and (ne (trim $header "") "") (not (in $uniqueCategories $header)) }} 
-          {{ $uniqueCategories = $uniqueCategories | append $header }} 
-        {{ end }} 
-      {{ end }} 
-    {{ end }} 
-  {{ end }} 
+{{ if $data }}
+  {{ $header := index $data 1 }}
 
-  {{ range $index, $category := $uniqueCategories }}
+  {{/* Column positions, resolved once */}}
+  {{ $functionIndex := -1 }}
+  {{ $featureIndex := -1 }}
+  {{ range $j, $col := $header }}
+    {{ if eq $col "Function" }}{{ $functionIndex = $j }}{{ end }}
+    {{ if eq $col "Feature" }}{{ $featureIndex = $j }}{{ end }}
+  {{ end }}
+  {{ if or (lt $functionIndex 0) (lt $featureIndex 0) }}
+    {{ errorf "role-tables: %q is missing a Function or Feature column. See %s" $src $.Position }}
+  {{ end }}
+
+  {{/* Role columns: index 4 up to "Keychain ID" */}}
+  {{ $roles := slice }}
+  {{ range $i, $col := $header }}
+    {{ if gt $i 3 }}
+      {{ if eq $col "Keychain ID" }}{{ break }}{{ end }}
+      {{ if and (ne (trim $col " ") "") (not (in $roles $col)) }}
+        {{ $roles = $roles | append $col }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{ range $category := $roles }}
+    {{ $categoryIndex := -1 }}
+    {{ range $j, $col := $header }}
+      {{ if eq $col $category }}{{ $categoryIndex = $j }}{{ end }}
+    {{ end }}
+
     <div class="csvtable-div">
       {{ $sectionName := $category | lower }}
       {{ $urlPath := "roles" }}
@@ -40,77 +74,30 @@
       {{ else if hasPrefix $sectionName "provider" }}
         {{ $urlPath = "roles/#provider-admin-role" }}
       {{ else }}
-        {{ $urlPath = print "roles/" $sectionName | urlize }}
+        {{ $urlPath = print "roles/" (urlize $sectionName) }}
       {{ end }}
       <h2><a href="/cloud/security/{{ $urlPath }}">{{ $category }} Role</a></h2>
       <table class="csvtable td-initial">
         <thead>
           <tr>
-            {{ range $i, $col := index $data 1 }} 
-              {{ if and (not (in $excludedColumns $i)) (or (eq $i 0) (ne $i 1) (ne $i 2)) }} 
-                {{ if and (eq $i 1) }}
-                  <th>Permission</th>
-                {{ else }} 
-                  {{ if and (eq $i 2) }}
-                    <th>Description</th>
-                  {{ end }}
-                {{ end }} 
-              {{ end }} 
-            {{ end }}
+            <th>Permission</th>
+            <th>Description</th>
           </tr>
         </thead>
         <tbody>
-          {{ range $i, $row := $data }} 
-            {{ if gt $i 0 }} 
-              {{/* Skip the header row */}}
-              {{ $hasAccess := false }} 
-              {{/* Flag to track if the row has access for the category */}}
-              {{ $functionValue := "" }} 
-              {{/* Variable to hold the Function value */}}
-              {{ $featureValue := "" }} 
-              {{/* Variable to hold the Feature value */}}
-
-              {{/* Find the column indices for Category, Function, and Feature */}}
-              {{ $categoryIndex := -1 }}
-              {{ $functionIndex := -1 }}
-              {{ $featureIndex := -1 }}
-              {{ range $j, $header := index $data 1 }} 
-                {{/* Assuming the first row contains headers */}}
-                {{ if eq $header $category }} 
-                  {{/* Check if the header matches the current category */}}
-                  {{ $categoryIndex = $j }}
-                {{ end }}
-                {{ if eq $header "Function" }}
-                  {{ $functionIndex = $j }}
-                {{ end }}
-                {{ if eq $header "Feature" }}
-                  {{ $featureIndex = $j }}
-                {{ end }}
+          {{ range $i, $row := $data }}
+            {{ if gt $i 1 }}
+              {{ $cell := index $row $categoryIndex }}
+              {{ if or (eq $cell "X") (eq $cell "X*") }}
+                <tr>
+                  <td>{{ index $row $functionIndex }}</td>
+                  <td>{{ index $row $featureIndex }}</td>
+                </tr>
               {{ end }}
-              
-              {{/* Check if the row has access for the category */}}
-              {{ if and (ge $categoryIndex 0) (or (eq (index $row $categoryIndex) "X") (eq (index $row $categoryIndex) "X*")) }}
-                {{ $hasAccess = true }}
-              {{ end }}
-              {{/* Get the Function and Feature values if the row has access */}}
-              {{ if $hasAccess }}
-                {{ $functionValue = index $row $functionIndex }}
-                {{ $featureValue = index $row $featureIndex }}
-              {{ end }}
-
-              {{/* Print the row if it has access */}}
-              {{ if $hasAccess }}
-              <tr>
-                <td>{{ $functionValue }} </td>
-                <td>{{ $featureValue }}</td>
-              </tr>
-              {{ end }}
-            {{ end }} 
+            {{ end }}
           {{ end }}
         </tbody>
       </table>
     </div>
-  {{ end }} 
-{{ else }}
-  <p>No data available.</p>
+  {{ end }}
 {{ end }}

--- a/layouts/shortcodes/csvtable-roles.html
+++ b/layouts/shortcodes/csvtable-roles.html
@@ -2,102 +2,110 @@
   Renders a permissions CSV as one table per role, listing the permissions
   that role has access to.
   Usage:
-  {{< role-tables src="keys-backup.csv" >}}
-  {{< role-tables src="static/data/csv/keys-backup.csv" >}}
+  {{< csvtable-roles >}}
+  {{< csvtable-roles src="keys-backup.csv" >}}
+  {{< csvtable-roles src="static/data/csv/keys-backup.csv" >}}
 
   Params:
-  src - path to the CSV. Resolved against the page bundle first, then
-        assets/, then the project root.
+  src       - path to the CSV. Resolved against the page bundle first, then
+              assets/, then the project root. Defaults to
+              static/data/csv/keys-backup.csv.
+  headerRow - 0-based index of the header row. Default 0. Set to 1 for a CSV
+              with a title row above the header.
 
-  Expected CSV shape: row 1 is the header, columns 2 and 3 are Function and
-  Feature, role columns run from column 5 up to "Keychain ID". A row is
-  listed under a role when that role's cell is X or X*.
+  Expected CSV shape: every column that isn't Category, Function, Feature, or
+  metadata (Keychain ID, Key ID, Inserted, Local Provider) is treated as a
+  role. A row is listed under a role when that role's cell is X or X*.
 */}}
-{{- $src := .Get "src" -}}
+{{- $src := .Get "src" | default "static/data/csv/keys-backup.csv" -}}
+{{- $headerRow := int (.Get "headerRow" | default 0) -}}
+{{- $nonRoleColumns := slice "Category" "Function" "Feature" "Keychain ID" "Key ID" "Inserted" "Local Provider" -}}
 {{- $opts := dict "delimiter" "," -}}
 {{- $data := "" -}}
 
-{{- if not $src -}}
-  {{- errorf "role-tables: src required. See %s" .Position -}}
+{{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
+  {{- $data = transform.Unmarshal $opts . -}}
 {{- else -}}
-  {{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
-    {{- $data = transform.Unmarshal $opts . -}}
+  {{- if os.FileExists $src -}}
+    {{- $data = transform.Unmarshal $opts (os.ReadFile $src) -}}
   {{- else -}}
-    {{- if os.FileExists $src -}}
-      {{- $data = transform.Unmarshal $opts (os.ReadFile $src) -}}
-    {{- else -}}
-      {{- errorf "role-tables: %q not found in page bundle, assets, or project root. See %s" $src .Position -}}
-    {{- end -}}
+    {{- errorf "csvtable-roles: %q not found in page bundle, assets, or project root. See %s" $src .Position -}}
   {{- end -}}
 {{- end -}}
 
 {{ if $data }}
-  {{ $header := index $data 1 }}
+  {{ if ge $headerRow (len $data) }}
+    {{ errorf "csvtable-roles: headerRow %d is past the end of %q. See %s" $headerRow $src $.Position }}
+  {{ else }}
 
-  {{/* Column positions, resolved once */}}
-  {{ $functionIndex := -1 }}
-  {{ $featureIndex := -1 }}
-  {{ range $j, $col := $header }}
-    {{ if eq $col "Function" }}{{ $functionIndex = $j }}{{ end }}
-    {{ if eq $col "Feature" }}{{ $featureIndex = $j }}{{ end }}
-  {{ end }}
-  {{ if or (lt $functionIndex 0) (lt $featureIndex 0) }}
-    {{ errorf "role-tables: %q is missing a Function or Feature column. See %s" $src $.Position }}
-  {{ end }}
-
-  {{/* Role columns: index 4 up to "Keychain ID" */}}
-  {{ $roles := slice }}
-  {{ range $i, $col := $header }}
-    {{ if gt $i 3 }}
-      {{ if eq $col "Keychain ID" }}{{ break }}{{ end }}
-      {{ if and (ne (trim $col " ") "") (not (in $roles $col)) }}
-        {{ $roles = $roles | append $col }}
-      {{ end }}
+    {{ $header := slice }}
+    {{ range $col := index $data $headerRow }}
+      {{ $header = $header | append (trim $col " ") }}
     {{ end }}
-  {{ end }}
 
-  {{ range $category := $roles }}
-    {{ $categoryIndex := -1 }}
+    {{/* Column positions, resolved once */}}
+    {{ $functionIndex := -1 }}
+    {{ $featureIndex := -1 }}
     {{ range $j, $col := $header }}
-      {{ if eq $col $category }}{{ $categoryIndex = $j }}{{ end }}
+      {{ if eq $col "Function" }}{{ $functionIndex = $j }}{{ end }}
+      {{ if eq $col "Feature" }}{{ $featureIndex = $j }}{{ end }}
     {{ end }}
 
-    <div class="csvtable-div">
-      {{ $sectionName := $category | lower }}
-      {{ $urlPath := "roles" }}
-      {{ if hasPrefix $sectionName "workspace" }}
-        {{ $urlPath = "roles/workspace-roles" }}
-      {{ else if hasPrefix $sectionName "team" }}
-        {{ $urlPath = "roles/team-roles" }}
-      {{ else if hasPrefix $sectionName "org" }}
-        {{ $urlPath = "roles/organization-roles" }}
-      {{ else if hasPrefix $sectionName "provider" }}
-        {{ $urlPath = "roles/#provider-admin-role" }}
-      {{ else }}
-        {{ $urlPath = print "roles/" (urlize $sectionName) }}
+    {{ if or (lt $functionIndex 0) (lt $featureIndex 0) }}
+      {{ errorf "csvtable-roles: %q is missing a Function or Feature column in row %d. See %s" $src $headerRow $.Position }}
+    {{ else }}
+
+      {{/* Role columns: anything not excluded, paired with its position */}}
+      {{ $roles := slice }}
+      {{ $seen := slice }}
+      {{ range $j, $col := $header }}
+        {{ if and (ne $col "") (not (in $nonRoleColumns $col)) (not (in $seen $col)) }}
+          {{ $seen = $seen | append $col }}
+          {{ $roles = $roles | append (dict "name" $col "index" $j) }}
+        {{ end }}
       {{ end }}
-      <h2><a href="/cloud/security/{{ $urlPath }}">{{ $category }} Role</a></h2>
-      <table class="csvtable td-initial">
-        <thead>
-          <tr>
-            <th>Permission</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{ range $i, $row := $data }}
-            {{ if gt $i 1 }}
-              {{ $cell := index $row $categoryIndex }}
-              {{ if or (eq $cell "X") (eq $cell "X*") }}
-                <tr>
-                  <td>{{ index $row $functionIndex }}</td>
-                  <td>{{ index $row $featureIndex }}</td>
-                </tr>
-              {{ end }}
-            {{ end }}
+
+      {{ range $role := $roles }}
+        <div class="csvtable-div">
+          {{ $sectionName := $role.name | lower }}
+          {{ $urlPath := "roles" }}
+          {{ if hasPrefix $sectionName "workspace" }}
+            {{ $urlPath = "roles/workspace-roles" }}
+          {{ else if hasPrefix $sectionName "team" }}
+            {{ $urlPath = "roles/team-roles" }}
+          {{ else if hasPrefix $sectionName "org" }}
+            {{ $urlPath = "roles/organization-roles" }}
+          {{ else if hasPrefix $sectionName "provider" }}
+            {{ $urlPath = "roles/#provider-admin-role" }}
+          {{ else }}
+            {{ $urlPath = print "roles/" (urlize $sectionName) }}
+            {{ warnf "csvtable-roles: no URL mapping for role %q, guessing %q. See %s" $role.name $urlPath $.Position }}
           {{ end }}
-        </tbody>
-      </table>
-    </div>
+          <h2><a href="/cloud/security/{{ $urlPath }}">{{ $role.name }} Role</a></h2>
+          <table class="csvtable td-initial">
+            <thead>
+              <tr>
+                <th>Permission</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{ range $i, $row := $data }}
+                {{ if gt $i $headerRow }}
+                  {{ $cell := trim (index $row $role.index) " " }}
+                  {{ if or (eq $cell "X") (eq $cell "X*") }}
+                    <tr>
+                      <td>{{ index $row $functionIndex }}</td>
+                      <td>{{ index $row $featureIndex }}</td>
+                    </tr>
+                  {{ end }}
+                {{ end }}
+              {{ end }}
+            </tbody>
+          </table>
+        </div>
+      {{ end }}
+
+    {{ end }}
   {{ end }}
 {{ end }}

--- a/layouts/shortcodes/csvtable-roles.html
+++ b/layouts/shortcodes/csvtable-roles.html
@@ -43,7 +43,6 @@
       {{ $header = $header | append (trim $col " ") }}
     {{ end }}
 
-    {{/* Column positions, resolved once */}}
     {{ $functionIndex := -1 }}
     {{ $featureIndex := -1 }}
     {{ range $j, $col := $header }}
@@ -54,8 +53,6 @@
     {{ if or (lt $functionIndex 0) (lt $featureIndex 0) }}
       {{ errorf "csvtable-roles: %q is missing a Function or Feature column in row %d. See %s" $src $headerRow $.Position }}
     {{ else }}
-
-      {{/* Role columns: anything not excluded, paired with its position */}}
       {{ $roles := slice }}
       {{ $seen := slice }}
       {{ range $j, $col := $header }}
@@ -77,6 +74,8 @@
             {{ $urlPath = "roles/organization-roles" }}
           {{ else if hasPrefix $sectionName "provider" }}
             {{ $urlPath = "roles/#provider-admin-role" }}
+          {{ else if hasPrefix $sectionName "user" }}
+            {{ $urlPath = "roles/user-role" }}
           {{ else }}
             {{ $urlPath = print "roles/" (urlize $sectionName) }}
             {{ warnf "csvtable-roles: no URL mapping for role %q, guessing %q. See %s" $role.name $urlPath $.Position }}

--- a/layouts/shortcodes/csvtable.html
+++ b/layouts/shortcodes/csvtable.html
@@ -1,23 +1,39 @@
-{{ $data := "" }}
+{{/*
+  Renders a permissions CSV as one table per category.
+  Usage:
+  {{< permissions-table src="keys-backup.csv" >}}
+  {{< permissions-table src="static/data/csv/keys-backup.csv" >}}
 
-{{ $p := "static/data/csv/keys-backup.csv" }}
-{{ $excludedColumns := slice "Category" "Keychain ID" "Key ID" "Inserted" "Local Provider" }} <!-- Add the names of the columns to exclude -->
+  Params:
+  src - path to the CSV. Resolved against the page bundle first, then
+        assets/, then the project root.
 
-{{ if os.FileExists $p }}
-  {{ $opts := dict "delimiter" "," }}
-  {{ $data = (os.ReadFile $p | transform.Unmarshal $opts) }}
-{{ else }}
-  {{ errorf "Unable to get resource %q" $p }}
-{{ end }}
+  Expected CSV shape: row 1 is a title row (skipped), row 2 is the header,
+  column 1 is the category. Columns 4-10 render X / X* as ✅ / ✅ *,
+  anything else as ❌.
+*/}}
+{{- $src := .Get "src" -}}
+{{- $excludedColumns := slice "Category" "Keychain ID" "Key ID" "Inserted" "Local Provider" -}}
+{{- $opts := dict "delimiter" "," -}}
+{{- $data := "" -}}
+
+{{- if not $src -}}
+  {{- errorf "permissions-table: src required. See %s" .Position -}}
+{{- else -}}
+  {{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
+    {{- $data = transform.Unmarshal $opts . -}}
+  {{- else -}}
+    {{- if os.FileExists $src -}}
+      {{- $data = transform.Unmarshal $opts (os.ReadFile $src) -}}
+    {{- else -}}
+      {{- errorf "permissions-table: %q not found in page bundle, assets, or project root. See %s" $src .Position -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 
 {{ if $data }}
-  {{ $uniqueCategories := slice }}
   {{ $header := index $data 1 }}
-  {{ $headerMap := dict }}
-
-  {{ range $i, $col := $header }}
-    {{ $headerMap = merge $headerMap (dict $col $i) }}
-  {{ end }}
+  {{ $uniqueCategories := slice }}
 
   {{ range $i, $row := $data }}
     {{ if gt $i 1 }}
@@ -28,12 +44,12 @@
     {{ end }}
   {{ end }}
 
-  {{ range $index, $category := $uniqueCategories }}
+  {{ range $category := $uniqueCategories }}
     <h2>{{ $category }} Permissions</h2>
     <table class="csvtable td-initial">
       <thead>
         <tr>
-          {{ range $i, $col := $header }}
+          {{ range $col := $header }}
             {{ if not (in $excludedColumns $col) }}
               {{ if eq $col "Function" }}
                 <th>Permission</th>
@@ -52,8 +68,6 @@
                   {{ $urlPath = "roles/#provider-admin-role" }}
                 {{ else if hasPrefix $sectionName "user" }}
                   {{ $urlPath = "roles/user-role" }}
-                {{ else }}
-                  {{ $urlPath = print "roles/" }}
                 {{ end }}
                 <th><a href="/cloud/security/{{ $urlPath }}">{{ $col }}</a></th>
               {{ end }}
@@ -89,7 +103,4 @@
       </tbody>
     </table>
   {{ end }}
-
-{{ else }}
-  <p>No data available.</p>
 {{ end }}

--- a/layouts/shortcodes/csvtable.html
+++ b/layouts/shortcodes/csvtable.html
@@ -1,106 +1,118 @@
 {{/*
   Renders a permissions CSV as one table per category.
   Usage:
-  {{< permissions-table src="keys-backup.csv" >}}
-  {{< permissions-table src="static/data/csv/keys-backup.csv" >}}
+  {{< csvtable >}}
+  {{< csvtable src="keys-backup.csv" >}}
+  {{< csvtable src="static/data/csv/keys-backup.csv" >}}
 
   Params:
-  src - path to the CSV. Resolved against the page bundle first, then
-        assets/, then the project root.
+  src       - path to the CSV. Resolved against the page bundle first, then
+              assets/, then the project root. Defaults to
+              static/data/csv/keys-backup.csv.
+  headerRow - 0-based index of the header row. Default 0. Set to 1 for a CSV
+              with a title row above the header.
 
-  Expected CSV shape: row 1 is a title row (skipped), row 2 is the header,
-  column 1 is the category. Columns 4-10 render X / X* as ✅ / ✅ *,
-  anything else as ❌.
+  Expected CSV shape: column 0 is the category; columns Function and Feature
+  render as raw text; every other non-metadata column is a role, rendering
+  X / X* as ✅ / ✅ *, anything else as ❌. Metadata columns
+  (Keychain ID, Key ID, Inserted, Local Provider) are hidden.
 */}}
-{{- $src := .Get "src" -}}
+{{- $src := .Get "src" | default "static/data/csv/keys-backup.csv" -}}
+{{- $headerRow := int (.Get "headerRow" | default 0) -}}
 {{- $excludedColumns := slice "Category" "Keychain ID" "Key ID" "Inserted" "Local Provider" -}}
 {{- $opts := dict "delimiter" "," -}}
 {{- $data := "" -}}
 
-{{- if not $src -}}
-  {{- errorf "permissions-table: src required. See %s" .Position -}}
+{{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
+  {{- $data = transform.Unmarshal $opts . -}}
 {{- else -}}
-  {{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
-    {{- $data = transform.Unmarshal $opts . -}}
+  {{- if os.FileExists $src -}}
+    {{- $data = transform.Unmarshal $opts (os.ReadFile $src) -}}
   {{- else -}}
-    {{- if os.FileExists $src -}}
-      {{- $data = transform.Unmarshal $opts (os.ReadFile $src) -}}
-    {{- else -}}
-      {{- errorf "permissions-table: %q not found in page bundle, assets, or project root. See %s" $src .Position -}}
-    {{- end -}}
+    {{- errorf "csvtable: %q not found in page bundle, assets, or project root. See %s" $src .Position -}}
   {{- end -}}
 {{- end -}}
 
 {{ if $data }}
-  {{ $header := index $data 1 }}
-  {{ $uniqueCategories := slice }}
+  {{ if ge $headerRow (len $data) }}
+    {{ errorf "csvtable: headerRow %d is past the end of %q. See %s" $headerRow $src $.Position }}
+  {{ else }}
 
-  {{ range $i, $row := $data }}
-    {{ if gt $i 1 }}
-      {{ $category := trim (index $row 0) " " }}
-      {{ if not (in $uniqueCategories $category) }}
-        {{ $uniqueCategories = $uniqueCategories | append $category }}
+    {{ $header := slice }}
+    {{ range $col := index $data $headerRow }}
+      {{ $header = $header | append (trim $col " ") }}
+    {{ end }}
+
+    {{ $uniqueCategories := slice }}
+    {{ range $i, $row := $data }}
+      {{ if gt $i $headerRow }}
+        {{ $category := trim (index $row 0) " " }}
+        {{ if not (in $uniqueCategories $category) }}
+          {{ $uniqueCategories = $uniqueCategories | append $category }}
+        {{ end }}
       {{ end }}
     {{ end }}
-  {{ end }}
 
-  {{ range $category := $uniqueCategories }}
-    <h2>{{ $category }} Permissions</h2>
-    <table class="csvtable td-initial">
-      <thead>
-        <tr>
-          {{ range $col := $header }}
-            {{ if not (in $excludedColumns $col) }}
-              {{ if eq $col "Function" }}
-                <th>Permission</th>
-              {{ else if eq $col "Feature" }}
-                <th>Description</th>
-              {{ else }}
-                {{ $sectionName := $col | lower }}
-                {{ $urlPath := "roles" }}
-                {{ if hasPrefix $sectionName "workspace" }}
-                  {{ $urlPath = "roles/workspace-roles" }}
-                {{ else if hasPrefix $sectionName "team" }}
-                  {{ $urlPath = "roles/team-roles" }}
-                {{ else if hasPrefix $sectionName "org" }}
-                  {{ $urlPath = "roles/organization-roles" }}
-                {{ else if hasPrefix $sectionName "provider" }}
-                  {{ $urlPath = "roles/#provider-admin-role" }}
-                {{ else if hasPrefix $sectionName "user" }}
-                  {{ $urlPath = "roles/user-role" }}
+    {{ range $category := $uniqueCategories }}
+      <h2>{{ $category }} Permissions</h2>
+      <table class="csvtable td-initial">
+        <thead>
+          <tr>
+            {{ range $col := $header }}
+              {{ if not (in $excludedColumns $col) }}
+                {{ if eq $col "Function" }}
+                  <th>Permission</th>
+                {{ else if eq $col "Feature" }}
+                  <th>Description</th>
+                {{ else }}
+                  {{ $sectionName := $col | lower }}
+                  {{ $urlPath := "roles" }}
+                  {{ if hasPrefix $sectionName "workspace" }}
+                    {{ $urlPath = "roles/workspace-roles" }}
+                  {{ else if hasPrefix $sectionName "team" }}
+                    {{ $urlPath = "roles/team-roles" }}
+                  {{ else if hasPrefix $sectionName "org" }}
+                    {{ $urlPath = "roles/organization-roles" }}
+                  {{ else if hasPrefix $sectionName "provider" }}
+                    {{ $urlPath = "roles/#provider-admin-role" }}
+                  {{ else if hasPrefix $sectionName "user" }}
+                    {{ $urlPath = "roles/user-role" }}
+                  {{ end }}
+                  <th><a href="/cloud/security/{{ $urlPath }}">{{ $col }}</a></th>
                 {{ end }}
-                <th><a href="/cloud/security/{{ $urlPath }}">{{ $col }}</a></th>
               {{ end }}
             {{ end }}
-          {{ end }}
-        </tr>
-      </thead>
-      <tbody>
-        {{ range $i, $row := $data }}
-          {{ if and (gt $i 1) (eq (trim (index $row 0) " ") $category) }}
-            <tr>
-              {{ range $j, $cell := $row }}
-                {{ $col := index $header $j }}
-                {{ if not (in $excludedColumns $col) }}
-                  <td>
-                    {{ if and (gt $j 2) (lt $j 10) }}
-                      {{ if eq $cell "X" }}
-                        ✅
-                      {{ else if eq $cell "X*" }}
-                        ✅ *
+          </tr>
+        </thead>
+        <tbody>
+          {{ range $i, $row := $data }}
+            {{ if and (gt $i $headerRow) (eq (trim (index $row 0) " ") $category) }}
+              <tr>
+                {{ range $j, $cell := $row }}
+                  {{ $cell = trim $cell " " }}
+                  {{ $col := index $header $j }}
+                  {{ if not (in $excludedColumns $col) }}
+                    <td>
+                      {{ if or (eq $col "Function") (eq $col "Feature") }}
+                        {{ $cell }}
                       {{ else }}
-                        ❌
+                        {{ if eq $cell "X" }}
+                          ✅
+                        {{ else if eq $cell "X*" }}
+                          ✅ *
+                        {{ else }}
+                          ❌
+                        {{ end }}
                       {{ end }}
-                    {{ else }}
-                      {{ $cell }}
-                    {{ end }}
-                  </td>
+                    </td>
+                  {{ end }}
                 {{ end }}
-              {{ end }}
-            </tr>
+              </tr>
+            {{ end }}
           {{ end }}
-        {{ end }}
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    {{ end }}
+
   {{ end }}
 {{ end }}

--- a/layouts/shortcodes/lab-intro.html
+++ b/layouts/shortcodes/lab-intro.html
@@ -1,1 +1,11 @@
-{{ .Page.Scratch.Set "lab_intro" .Inner }}
+{{/*
+  Captures content for later output without rendering it in place.
+  Usage:
+  {{< lab-intro >}}
+    Your markdown content goes here.
+  {{< /lab-intro >}}
+
+  Output is emitted by {{< lab-outro >}}, which must appear later in the
+  same file.
+*/}}
+{{- .Page.Store.Set "lab_intro" .Inner -}}

--- a/layouts/shortcodes/lab-outro.html
+++ b/layouts/shortcodes/lab-outro.html
@@ -1,0 +1,10 @@
+{{/*
+  Renders the content captured by {{< lab-intro >}} earlier in the page.
+  Usage:
+  {{< lab-outro >}}
+*/}}
+{{- with .Page.Store.Get "lab_intro" -}}
+  {{- $.Page.RenderString (dict "display" "block") . -}}
+{{- else -}}
+  {{- warnf "lab-outro: no lab-intro found on this page. See %s" $.Position -}}
+{{- end -}}

--- a/layouts/shortcodes/svg.html
+++ b/layouts/shortcodes/svg.html
@@ -1,6 +1,28 @@
-{{ $name := .Get "name" }}
-{{ with resources.Get (printf "icons/%s.svg" $name) }}
-  {{ .Content | safeHTML }}
-{{ else }}
-  <!-- SVG not found: {{ $name }} -->
-{{ end }}
+{{/*
+  Shortcode to inline an SVG file, resolved from the page bundle first,
+  then the assets directory.
+  Usage:
+  {{< svg name="banana" >}}
+  {{< svg src="path/to/file.svg" >}}
+
+  Params:
+  name - filename without extension. Looks for "<name>.svg" in the page
+         bundle, falling back to "assets/icons/<name>.svg".
+  src  - explicit path including extension, relative to the page bundle
+         or to assets/. Takes precedence over name, so a copied file path
+         can be pasted as-is without stripping the filename.
+*/}}
+{{- $name := .Get "name" -}}
+{{- $src  := .Get "src" -}}
+
+{{- if not (or $name $src) -}}
+  {{- errorf "svg: name or src required. See %s" .Position -}}
+{{- else -}}
+  {{- $local  := or $src (printf "%s.svg" $name) -}}
+  {{- $global := or $src (printf "icons/%s.svg" $name) -}}
+  {{- with or (.Page.Resources.Get $local) (resources.Get $global) -}}
+    {{- .Content | safeHTML -}}
+  {{- else -}}
+    {{- warnf "svg: %q not found in page bundle, %q not in assets. See %s" $local $global .Position -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/shortcodes/swaggerui-api.html
+++ b/layouts/shortcodes/swaggerui-api.html
@@ -1,0 +1,50 @@
+{{/*
+  Renders a Swagger UI viewer for an OpenAPI spec, loading its own assets.
+  No front matter type is required.
+  Usage:
+  {{< swaggerui src="example.json" >}}
+  {{< swaggerui src="/data/openapi.json" >}}
+  {{< swaggerui src="https://petstore3.swagger.io/api/v3/openapi.json" >}}
+
+  Params:
+  src         - path to the spec. Absolute URLs and root-relative paths (files
+                under static/) are used as-is; anything else is resolved against
+                the page bundle, then assets/.
+  version     - optional swagger-ui-dist version, defaults to the pin below.
+  deepLinking - optional "true" to write the expanded operation into the URL
+                fragment. Off by default; only safe with one viewer per page.
+*/}}
+{{- $src := .Get "src" -}}
+{{- $version := .Get "version" | default "5.17.14" -}}
+{{- $deepLinking := eq (.Get "deepLinking" | default "false") "true" -}}
+{{- $base := printf "https://cdn.jsdelivr.net/npm/swagger-ui-dist@%s" $version -}}
+{{- $id := printf "swagger-ui-%d" .Ordinal -}}
+{{- $url := "" -}}
+
+{{- if not $src -}}
+  {{- errorf "swaggerui: src required. See %s" .Position -}}
+{{- else if or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
+  {{- $url = $src -}}
+{{- else -}}
+  {{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
+    {{- $url = .RelPermalink -}}
+  {{- else -}}
+    {{- errorf "swaggerui: %q not found in page bundle or assets. See %s" $src .Position -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with $url -}}
+  {{- if not ($.Page.Store.Get "swaggerui_loaded") -}}
+    {{- $.Page.Store.Set "swaggerui_loaded" true -}}
+    <link rel="stylesheet" href="{{ $base }}/swagger-ui.css">
+    <script src="{{ $base }}/swagger-ui-bundle.js"></script>
+  {{- end -}}
+  <div id="{{ $id }}"></div>
+  <script>
+    SwaggerUIBundle({
+      url: {{ . }},
+      dom_id: "#{{ $id }}",
+      deepLinking: {{ $deepLinking }}
+    });
+  </script>
+{{- end -}}

--- a/layouts/shortcodes/swaggerui-api.html
+++ b/layouts/shortcodes/swaggerui-api.html
@@ -2,42 +2,51 @@
   Renders a Swagger UI viewer for an OpenAPI spec, loading its own assets.
   No front matter type is required.
   Usage:
-  {{< swaggerui src="example.json" >}}
-  {{< swaggerui src="/data/openapi.json" >}}
-  {{< swaggerui src="https://petstore3.swagger.io/api/v3/openapi.json" >}}
+  {{< swaggerui-api src="example.json" >}}
+  {{< swaggerui-api src="/data/openapi.json" >}}
 
   Params:
-  src         - path to the spec. Absolute URLs and root-relative paths (files
-                under static/) are used as-is; anything else is resolved against
-                the page bundle, then assets/.
-  version     - optional swagger-ui-dist version, defaults to the pin below.
+  src         - path to the spec, which must be part of this site. Root-relative
+                paths (files under static/) are used as-is; anything else is
+                resolved against the page bundle, then assets/. Remote URLs are
+                not accepted.
   deepLinking - optional "true" to write the expanded operation into the URL
                 fragment. Off by default; only safe with one viewer per page.
+
+  swagger-ui-dist is pinned with SRI hashes below. To bump it, update $version
+  and both hashes together:
+    curl -sL https://cdn.jsdelivr.net/npm/swagger-ui-dist@<ver>/swagger-ui.css \
+      | openssl dgst -sha384 -binary | openssl base64 -A
 */}}
-{{- $src := .Get "src" -}}
-{{- $version := .Get "version" | default "5.17.14" -}}
-{{- $deepLinking := eq (.Get "deepLinking" | default "false") "true" -}}
+{{- $version := "5.32.11" -}}
+{{- $cssIntegrity := "sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT" -}}
+{{- $jsIntegrity := "sha384-vfl/klfTFrIz5urj0HnhcXLAbzPdRHezizfy+XgFB6GqcKkhlk0lS3bIbyB39NLA" -}}
 {{- $base := printf "https://cdn.jsdelivr.net/npm/swagger-ui-dist@%s" $version -}}
+
+{{- $src := .Get "src" -}}
+{{- $deepLinking := eq (.Get "deepLinking" | default "false") "true" -}}
 {{- $id := printf "swagger-ui-%d" .Ordinal -}}
 {{- $url := "" -}}
 
 {{- if not $src -}}
-  {{- errorf "swaggerui: src required. See %s" .Position -}}
-{{- else if or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "/") -}}
+  {{- errorf "swaggerui-api: src required. See %s" .Position -}}
+{{- else if or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "//") -}}
+  {{- errorf "swaggerui-api: remote specs are not supported, %q must be a file in this site. See %s" $src .Position -}}
+{{- else if hasPrefix $src "/" -}}
   {{- $url = $src -}}
 {{- else -}}
   {{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
     {{- $url = .RelPermalink -}}
   {{- else -}}
-    {{- errorf "swaggerui: %q not found in page bundle or assets. See %s" $src .Position -}}
+    {{- errorf "swaggerui-api: %q not found in page bundle or assets. See %s" $src .Position -}}
   {{- end -}}
 {{- end -}}
 
 {{- with $url -}}
   {{- if not ($.Page.Store.Get "swaggerui_loaded") -}}
     {{- $.Page.Store.Set "swaggerui_loaded" true -}}
-    <link rel="stylesheet" href="{{ $base }}/swagger-ui.css">
-    <script src="{{ $base }}/swagger-ui-bundle.js"></script>
+    <link rel="stylesheet" href="{{ $base }}/swagger-ui.css" integrity="{{ $cssIntegrity }}" crossorigin="anonymous">
+    <script src="{{ $base }}/swagger-ui-bundle.js" integrity="{{ $jsIntegrity }}" crossorigin="anonymous"></script>
   {{- end -}}
   <div id="{{ $id }}"></div>
   <script>

--- a/layouts/shortcodes/swaggerui-api.html
+++ b/layouts/shortcodes/swaggerui-api.html
@@ -7,9 +7,9 @@
 
   Params:
   src         - path to the spec, which must be part of this site. Root-relative
-                paths (files under static/) are used as-is; anything else is
-                resolved against the page bundle, then assets/. Remote URLs are
-                not accepted.
+                paths (files under static/) are resolved against baseURL;
+                anything else is resolved against the page bundle, then
+                assets/. Remote URLs are not accepted.
   deepLinking - optional "true" to write the expanded operation into the URL
                 fragment. Off by default; only safe with one viewer per page.
 
@@ -33,7 +33,7 @@
 {{- else if or (hasPrefix $src "http://") (hasPrefix $src "https://") (hasPrefix $src "//") -}}
   {{- errorf "swaggerui-api: remote specs are not supported, %q must be a file in this site. See %s" $src .Position -}}
 {{- else if hasPrefix $src "/" -}}
-  {{- $url = $src -}}
+  {{- $url = relURL (strings.TrimPrefix "/" $src) -}}
 {{- else -}}
   {{- with or (.Page.Resources.Get $src) (resources.Get $src) -}}
     {{- $url = .RelPermalink -}}


### PR DESCRIPTION
## Summary

Shortcodes that read files were hardcoded to a single location.
All of them now resolve `src` against the **page bundle first, then `assets/`**,
so colocated assets work. Each also gained a usage comment and a build-time
error instead of failing silently.

## `svg`

- Fixed `.Resources` → `.Page.Resources`. In a shortcode `.` is the shortcode,
  not the page, so page-bundle lookup never worked.
- Collapsed the `$r` + `if not $r` reassignment into a single
  `with or (...) (...)` / `else` chain.
- Added `src` param for an explicit path, taking precedence over `name`.
- Missing file now `warnf`s with both attempted paths instead of emitting an
  HTML comment.
- Guard for neither `name` nor `src` being passed.

## `chapterstyle`

- Fixed `style` never rendering: Go's autoescaper voids unparseable CSS
  attributes as `ZgotmplZ`. Added `safeCSS`.
- Fixed `.Inner` rendering inline: `RenderString` now gets
  `(dict "display" "block")` so multi-paragraph content is wrapped in `<p>`.
- Dropped a redundant `| default ""`.

## `lab-intro` / `lab-outro` (new)

- `lab-intro` stores raw `.Inner`; rendering moved to output time.
- New `lab-outro` shortcode renders it, replacing the manual
  `Scratch.Get` call at each site.
- `.Scratch` → `.Store`.
- Warns if `lab-outro` runs without a preceding `lab-intro`.

## `csvtable` (one table per category)

- Added `src` param — resolves page bundle → `assets/` → project root.
  Defaults to `static/data/csv/keys-backup.csv`, so existing bare call sites
  are unaffected.
- **Fixed the header row.** Code read row 1; `keys-backup.csv` has its header
  at row 0, so the first data row was rendering as the header. New `headerRow`
  param, default 0.
- Checkmark cells now identified by column name instead of a hardcoded index
  range (3–9), which had to stay manually in sync with the exclusion list.
- Removed dead code: `$headerMap`, an HTML comment shipping to output, a
  no-op `else` branch, and an unreachable "No data available" tail.

## `csvtable-roles` (one table per role)

- Same `src` param and `headerRow` fix. The wrong row broke the build here:
  it scanned a data row for Function/Feature and errored out.
- **Roles now identified by name instead of position.** The old `gt $i 3`
  bound silently dropped **Workspace Admin** — that role never got a table.
- Removed `$hasAccess` / `$functionValue` / `$featureValue` and the
  `$stopAddingCategories` flag; hoisted the Function/Feature lookup out of the
  per-row loop, which was rescanning the header for every row of every table.
- Fixed pipe precedence in `print "roles/" $sectionName | urlize`, which
  slugified the slash along with the name.
- Added a warning when a role name matches no URL branch — the fallback
  guesses a slug and would otherwise ship a silent 404.

## `swaggerui-api`

- Loads `swagger-ui.css` and `swagger-ui-bundle.js` itself, so no front matter
  type is required. Emitted once per page via `.Page.Store`.
- Added `src` param — root-relative paths pass through, anything else resolves
  against the page bundle, then `assets/`. Remote URLs are rejected; the spec
  must be part of this site.
- CDN assets pinned to `swagger-ui-dist@5.32.11` with `integrity` and
  `crossorigin`, matching how `layouts/swagger/baseof.html` already loads them.
- `deepLinking` off by default — multiple viewers on one page collide over the
  URL fragment. Opt in per call.
- `.Ordinal` gives each instance a unique `dom_id`.
- Dropped `StandaloneLayout` and its preset: that's the spec-URL topbar, which
  Docsy hides with CSS anyway.

## Not included

`iframe` — page-bundled `.html` is classified by Hugo as a page resource with
no permalink, so it needs either a site-config change or a republish step.
Deferred.

## Notes for Reviewers
- Follow up work from formatting done in https://github.com/meshery-extensions/tcslabs-academy/pull/48

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a `swaggerui-api` shortcode to render Swagger UI for local OpenAPI specs, with optional deep linking.
  - Added a `lab-outro` shortcode to display previously defined `lab-intro` content.

- **Improvements**
  - Enhanced `csvtable` and `csvtable-roles` with `src` and `headerRow` parameters, more flexible CSV loading, and improved permission/role rendering.
  - Updated the `svg` shortcode to accept `name` or `src`, with clearer validation and warning behavior when files aren’t found.
  - Refined `chapterstyle` for more consistent inner rendering and safer handling of optional styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->